### PR TITLE
feat(asdf): add asdf to host

### DIFF
--- a/config/recipe.yml
+++ b/config/recipe.yml
@@ -39,3 +39,4 @@ modules:
     scripts:
       # set up the proper policy & signing files for signed images to work
       - signing.sh
+      - setup-asdf.sh

--- a/config/scripts/setup-asdf.sh
+++ b/config/scripts/setup-asdf.sh
@@ -12,8 +12,8 @@ if [[ ! -f $(which git) || ! -f $(which curl) ]]; then
     exit 1
 fi
 
-ASDF_DIR=/opt/asdf
-FISH_DIR=/etc/fish
+ASDF_DIR=/usr/opt/asdf
+FISH_DIR=/usr/etc/fish
 
 echo '2. Downloading source'
 git clone https://github.com/asdf-vm/asdf.git $ASDF_DIR --branch v0.13.1

--- a/config/scripts/setup-asdf.sh
+++ b/config/scripts/setup-asdf.sh
@@ -12,11 +12,14 @@ if [[ ! -f $(which git) || ! -f $(which curl) ]]; then
     exit 1
 fi
 
+ASDF_DIR=/opt/asdf
+FISH_DIR=/etc/fish
+
 echo '2. Downloading source'
-git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.13.1
+git clone https://github.com/asdf-vm/asdf.git $ASDF_DIR --branch v0.13.1
 
 echo '3. Install (for fish)'
-echo 'source ~/.asdf/asdf.fish' >> ~/.config/fish/config.fish
+echo "source $ASDF_DIR/asdf.fish" >> $FISH_DIR/config.fish
 
 echo '4. Add completions (for fish)'
-mkdir -p ~/.config/fish/completions && ln -s ~/.asdf/completions/asdf.fish ~/.config/fish/completions
+mkdir -p $FISH_DIR/completions && ln -s $ASDF_DIR/completions/asdf.fish $FISH_DIR/completions

--- a/config/scripts/setup-asdf.sh
+++ b/config/scripts/setup-asdf.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Tell build process to exit if there are any errors.
+set -oue pipefail
+
+# This script automates the setup of asdf as described 
+# at: https://asdf-vm.com/guide/getting-started.html
+
+echo '1. Checking prerequisits'
+if [[ ! -f $(which git) || ! -f $(which curl) ]]; then
+    echo 'missing prerequisits'
+    exit 1
+fi
+
+echo '2. Downloading source'
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.13.1
+
+echo '3. Install (for fish)'
+echo 'source ~/.asdf/asdf.fish' >> ~/.config/fish/config.fish
+
+echo '4. Add completions (for fish)'
+mkdir -p ~/.config/fish/completions && ln -s ~/.asdf/completions/asdf.fish ~/.config/fish/completions


### PR DESCRIPTION
Adds a script that sets up asdf system-wide in `/usr/opt/asdf`.
Plugins are purposefully still installed in the users `~/.asdf` directory.

resolves: #12 