### PR TITLE
fix!: broken build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -28,13 +28,7 @@ ARG RECIPE=recipe.yml
 # The default image registry to write to policy.json and cosign.yaml
 ARG IMAGE_REGISTRY=ghcr.io/ublue-os
 
-
 COPY cosign.pub /usr/share/ublue-os/cosign.pub
-
-# Copy the bling from ublue-os/bling into tmp, to be installed later by the bling module
-# Feel free to remove these lines if you want to speed up image builds and don't want any bling
-COPY --from=ghcr.io/ublue-os/bling:latest /rpms /tmp/bling/rpms
-COPY --from=ghcr.io/ublue-os/bling:latest /files /tmp/bling/files
 
 # Copy build scripts & configuration
 COPY build.sh /tmp/build.sh
@@ -49,6 +43,9 @@ COPY modules /tmp/modules/
 # `yq` is used for parsing the yaml configuration
 # It is copied from the official container image since it's not available as an RPM.
 COPY --from=docker.io/mikefarah/yq /usr/bin/yq /usr/bin/yq
+
+# Change this if you want different version/tag of akmods.
+COPY --from=ghcr.io/ublue-os/akmods:main-39 /rpms /tmp/rpms
 
 # Run the build script, then clean up temp files and finalize container build.
 RUN chmod +x /tmp/build.sh && /tmp/build.sh && \

--- a/config/recipe.yml
+++ b/config/recipe.yml
@@ -31,6 +31,8 @@ modules:
       - gtkgreet
       - docker-ce
       - docker-ce-cli
+      - kubernetes-client
+      - docker-compose
     remove:
       - sddm
       - sddm-wayland-sway

--- a/config/recipe.yml
+++ b/config/recipe.yml
@@ -40,7 +40,6 @@ modules:
     install:
       - ublue-os-wallpapers
       - ublue-update
-      - container-tools # installs container-related tools onto /usr/bin: kind, kubectx, docker-compose and kubens
       - laptop # installs TLP and configures your system for laptop usage
 
   - type: script


### PR DESCRIPTION
Bling has changed how the modules are exported from their image.

Also the `container-tools` part is removed, so we need to replace these tools:

- `dive` - [asdf-plugin](https://github.com/looztra/asdf-dive)
- `docker-compose` - [fedora](https://packages.fedoraproject.org/pkgs/docker-compose/docker-compose/)
- `kind` - [asdf-plugin](https://github.com/johnlayton/asdf-kind)
- `kubectx` - [asdf-plugin](https://gitlab.com/wt0f/asdf-kubectx)
- `kubens` - [asdf-plugin](https://gitlab.com/wt0f/asdf-kubectx)
- `kubectl` - [fedora](https://packages.fedoraproject.org/pkgs/kubernetes/kubernetes-client/)

The tools that can be downloaded as official rpms are added in this PR: `docker-compose` and `kubectl`
The other ones can be installed as asdf plugins if needed until we can decide if/which/how they can be installed in the image.