### PR TITLE
feat: remove docker-compose

### DIFF
--- a/config/recipe.yml
+++ b/config/recipe.yml
@@ -32,7 +32,6 @@ modules:
       - docker-ce
       - docker-ce-cli
       - kubernetes-client
-      - docker-compose
     remove:
       - sddm
       - sddm-wayland-sway


### PR DESCRIPTION
`docker-compose` is part of `docker` through the subcommand `compose`. 
For example `docker compose up`