### PR TITLE
feat!: remove deprecated bling install

### DIFF
--- a/config/recipe.yml
+++ b/config/recipe.yml
@@ -43,7 +43,6 @@ modules:
     install:
       - ublue-os-wallpapers
       - ublue-update
-      - laptop # installs TLP and configures your system for laptop usage
 
   - type: script
     scripts:


### PR DESCRIPTION
Fixes failure in build: https://github.com/sidusio/sediment/actions/runs/10270891316/job/28419650616#step:2:1523

The `laptop` install was deprecated and has since
a couple of weeks now been removed.

We should look into a replacement to handle power
management, [`tuned`](https://github.com/redhat-performance/tuned) is an alternative.