### PR TITLE
feat: upgrade to Fedora version 41

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,12 +19,12 @@ COPY files/usr /usr
 
 # Swap SDDM for GDM
 RUN \
-  rpm-ostree override remove sddm sddm-wayland-sway && \
-  rpm-ostree install gdm && \
+  dnf override remove sddm sddm-wayland-sway && \
+  dnf install gdm && \
   systemctl enable gdm
 
 # Misc. packages
-RUN rpm-ostree install \
+RUN dnf install \
   fish \
   kubernetes-client \
   grim \
@@ -34,7 +34,7 @@ RUN rpm-ostree install \
 
 # Docker
 RUN curl -o "/etc/yum.repos.d/docker.com.linux.fedora.docker-ce.repo" "https://download.docker.com/linux/fedora/docker-ce.repo" && \
-  rpm-ostree install docker-ce docker-ce-cli && \
+  dnf install docker-ce docker-ce-cli && \
   systemctl enable docker
 
 # Fingerprint reader setup

--- a/Containerfile
+++ b/Containerfile
@@ -19,7 +19,7 @@ COPY files/usr /usr
 
 # Swap SDDM for GDM
 RUN \
-  dnf override remove sddm sddm-wayland-sway && \
+  dnf remove sddm sddm-wayland-sway && \
   dnf install gdm && \
   systemctl enable gdm
 

--- a/Containerfile
+++ b/Containerfile
@@ -19,7 +19,7 @@ COPY files/usr /usr
 
 # Swap SDDM for GDM
 RUN \
-  dnf remove --assumeyes sddm sddm-wayland-sway && \
+  dnf remove -y sddm sddm-wayland-sway && \
   dnf install gdm && \
   systemctl enable gdm
 

--- a/Containerfile
+++ b/Containerfile
@@ -19,7 +19,7 @@ COPY files/usr /usr
 
 # Swap SDDM for GDM
 RUN \
-  dnf remove sddm sddm-wayland-sway && \
+  dnf remove --assumeyes sddm sddm-wayland-sway && \
   dnf install gdm && \
   systemctl enable gdm
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG OS_VERSION=40
+ARG OS_VERSION=41
 
 FROM ghcr.io/ublue-os/sericea-main:$OS_VERSION
 


### PR DESCRIPTION
Fedora 41 images ship with `dnf`v5 + `bootc` which replaces most of the rpm-ostree functionality build-time.

Read more on the topic: [bootc/rpm-ostree](https://docs.fedoraproject.org/en-US/bootc/rpm-ostree/), [bootc/dnf](https://docs.fedoraproject.org/en-US/bootc/dnf/), [fedora wiki](https://fedoraproject.org/wiki/Changes/DNFAndBootcInImageModeFedora)

`rpm-ostree` may still be needed for **runtime** operations for a while.