### PR TITLE
chore: enable kanshi service

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -49,6 +49,9 @@ COPY --chmod=744 scripts/google-fonts.sh scripts/nerd-fonts.sh /tmp/
 RUN /tmp/google-fonts.sh "Roboto" "Open Sans"
 RUN /tmp/nerd-fonts.sh "FiraCode" "Hack" "SourceCodePro" "Terminus" "JetBrainsMono" "NerdFontsSymbolsOnly"
 
+# Enable kanshi service
+RUN systemctl --global enable kanshi
+
 # Setup signing
 COPY signing/policy.json /usr/etc/containers/
 COPY signing/cosign.pub /usr/etc/pki/containers/sediment.pub


### PR DESCRIPTION
Enable the builtin kanshi service by default.

Not that automatically applied kanshi profile may conflict with output options defined elsewhere. Thus the recommendation is to have all output config in kanshi.

example kanshi config file:
```
profile docked-framework {
	output "BOE 0x0BCA Unknown" enable position 0,0 scale 1.4
	output "ASUSTek COMPUTER INC VG248 LALMQS189681" position 1611,0 mode 1920x1080@60Hz
	output "AOC G2460 0x000000D8" position 3531,0
}
profile framework {
        output "BOE 0x0BCA Unknown" enable position 0,0 scale 1.4
}
profile docked-saiph {
        output "AU Optronics 0x9EA9 Unknown" position 0,0 scale 1.1
        output "ASUSTek COMPUTER INC VG248 LALMQS189681" position 1745,0 mode 1920x1080@60Hz
        output "AOC G2460 0x000000D8" position 3665,0
}
profile saiph {
        output "AU Optronics 0x9EA9 Unknown" position 0,0 scale 1.1
}
```