### PR TITLE
fix: configure DMS as default shell

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -39,11 +39,13 @@ RUN dnf install -y \
 # DankMaterial Shell
 RUN yes | dnf copr enable avengemedia/dms && \
   dnf install -y dms && \
-  systemctl enable /usr/lib/systemd/user/dms.service && \
+  systemctl --global enable dms.service && \
   dnf remove -y \
+  dunst \
   network-manager-applet \
   rofi \
   rofi-themes
+RUN systemctl --global is-enabled dms.service
 
 # Docker
 RUN curl -o "/etc/yum.repos.d/docker.com.linux.fedora.docker-ce.repo" "https://download.docker.com/linux/fedora/docker-ce.repo" && \

--- a/files/usr/etc/sway/config.d/50-dms-keybinds.conf
+++ b/files/usr/etc/sway/config.d/50-dms-keybinds.conf
@@ -1,0 +1,4 @@
+# DMS keybind overrides
+# Replace rofi launcher (removed in PR #104) with DMS spotlight
+set $menu dms ipc call spotlight toggle
+bindsym --no-warn $mod+d exec $menu

--- a/files/usr/etc/sway/config.d/90-bar.conf
+++ b/files/usr/etc/sway/config.d/90-bar.conf
@@ -1,0 +1,3 @@
+# Disabled: DMS provides DankBar
+# This empty override suppresses waybar from /usr/share/sway/config.d/90-bar.conf
+# via sway's layered-include basename deduplication mechanism

--- a/files/usr/etc/sway/config.d/90-swayidle.conf
+++ b/files/usr/etc/sway/config.d/90-swayidle.conf
@@ -1,0 +1,2 @@
+# Disabled: DMS manages its own idle/lock (FadeToLock + loginctl integration)
+# This empty override suppresses swayidle/swaylock from /usr/share/sway/config.d/90-swayidle.conf

--- a/files/usr/etc/xdg/autostart/blueman.desktop
+++ b/files/usr/etc/xdg/autostart/blueman.desktop
@@ -1,0 +1,2 @@
+[Desktop Entry]
+Hidden=true

--- a/files/usr/etc/xdg/blueman.desktop
+++ b/files/usr/etc/xdg/blueman.desktop
@@ -1,3 +1,0 @@
-[Desktop Entry]
-Name=Blueman Applet
-Type=Application


### PR DESCRIPTION
- Fix DMS user service enablement: replace broken `systemctl enable /usr/lib/systemd/user/dms.service` with correct `systemctl --global enable dms.service` (same pattern as kanshi)
- Add build-time verification: RUN systemctl --global is-enabled dms.service
- Remove dunst package (no reverse deps; DMS owns org.freedesktop.Notifications)
- Suppress waybar bar via empty sway config.d override (DMS provides DankBar; waybar cannot be removed as sway-config-fedora depends on it)
- Override $menu to DMS spotlight launcher (replaces removed rofi in $mod+d)
- Fix misplaced blueman.desktop from PR #104: move to xdg/autostart/ and disable with Hidden=true (DMS provides its own BluetoothService)